### PR TITLE
Populate BookForm's related fields.

### DIFF
--- a/ex_libris/books/views.py
+++ b/ex_libris/books/views.py
@@ -94,6 +94,20 @@ def detail(request, id):
             )
     else:
         form = BookForm(instance=book)
+        # TODO: including this here, rather than in the BookForm, is tech debt.
+        # However, due to some shenanigans (possibly involving metaclasses and
+        # the crispy forms library's templatetags?), overriding __init__ caused
+        # an exception to be raised. Until I figure out why, this is the
+        # solution.
+        initial = {
+            'author_name': book.author.name,
+            'publisher_name': book.publisher.name,
+            'series_name': book.series.name,
+        }
+        for k, v in initial.items():
+            field = form.fields.get(k)
+            if field:
+                field.initial = v
     return render(
         request,
         "books/detail.html",


### PR DESCRIPTION
Fixes #47.

### New behavior

The BookForm (to edit book metadata) no longer misses the values from the related models: Author, Publisher, and Series.

_As per our ancient tradition, a pull request must include a picture of a cute animal:_

![sleepy iguana](http://img00.deviantart.net/d018/a/large/photography/photoanimals/iguana_sleep.jpg)