### PR TITLE
Fix alignment of splash page.

### DIFF
--- a/ex_libris/templates/base.html
+++ b/ex_libris/templates/base.html
@@ -97,14 +97,16 @@
         <p>
           <a href="{% provider_login_url "custom_dropbox_oauth2" process="login" %}" class="btn btn-lg btn-primary" role="button">Log in via Dropbox</a>
         </p>
-        <p class="col-xs-6 col-xs-offset-3">
+        <div class="row">
+          <p class="col-sm-6 offset-sm-3">
           <small class="text-muted">
             Right now, we're in beta, and only can
             deal with PDF files in Dropbox. Sorry!
             We're working on expanding and improving
             what we offer, though.
           </small>
-        </p>
+          </p>
+        </div>
         <div class="clearfix"></div>
       </div>
       {% endblock content %}


### PR DESCRIPTION
I think the alpha version of Boostrap 4 I'm using drifted from their documentation, and so the alignment of the splash broke. Should really not be using an alpha of a frontend framework, but c'est la vie.