### PR TITLE
Undo the apparently-spurious layout changes.

### DIFF
--- a/ex_libris/templates/base.html
+++ b/ex_libris/templates/base.html
@@ -98,7 +98,7 @@
           <a href="{% provider_login_url "custom_dropbox_oauth2" process="login" %}" class="btn btn-lg btn-primary" role="button">Log in via Dropbox</a>
         </p>
         <div class="row">
-          <p class="col-sm-6 offset-sm-3">
+          <p class="col-sm-6 col-sm-offset-3">
           <small class="text-muted">
             Right now, we're in beta, and only can
             deal with PDF files in Dropbox. Sorry!
@@ -107,7 +107,6 @@
           </small>
           </p>
         </div>
-        <div class="clearfix"></div>
       </div>
       {% endblock content %}
     </div> <!-- /container -->


### PR DESCRIPTION
We should really get on a fixed version of Bootstrap, not just "latest v4 alpha".